### PR TITLE
temp fix: Add nitter to hosts file

### DIFF
--- a/.github/workflows/run_notifier.yml
+++ b/.github/workflows/run_notifier.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Run notifier
         env:
           DISCORD_WEBHOOK_MAIN_URL: ${{ secrets.DISCORD_WEBHOOK_MAIN_URL }}
-
-        run: python main.py
+        run: sudo echo "185.246.188.57 nitter.net" >> /etc/hosts && python main.py
 
       - name: Commit status.json
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
Not sure if github actions will let you edit this file, but giving it a shot.

nitter.net dns is currently not working: https://github.com/zedeus/nitter/issues/1150