### PR TITLE
replace nitter.net with twiiit

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-from bs4 import BeautifulSoup as bs
 from discord_webhook import DiscordWebhook
 
 import datetime
@@ -6,6 +5,7 @@ import os
 import requests
 import sqlite3
 import sys
+import xml.etree.ElementTree as ET
 
 # for testing. make sure you remove before commiting! :)
 TESTING_WEBHOOK_URL = ''
@@ -13,7 +13,7 @@ WEBHOOK_URLS = {
     'main': os.environ.get('DISCORD_WEBHOOK_MAIN_URL', TESTING_WEBHOOK_URL),
 }
 
-DQX_TWITTER = "https://nitter.net/DQ_X"
+DQX_TWITTER = "https://twiiit.com/DQ_X/rss"
 
 
 def notify_webhook(content: str):
@@ -31,45 +31,29 @@ db_file = 'state.db'
 conn = sqlite3.connect(db_file)
 cursor = conn.cursor()
 
-# sorry nitter! we're a low traffic bot :S
-headers = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/118.0",
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-    "Accept-Language": "en-US,en;q=0.5",
-    "Accept-Encoding": "gzip, deflate, br",
-    "DNT": "1",
-    "Connection": "keep-alive",
-    "Upgrade-Insecure-Requests": "1",
-    "Sec-Fetch-Dest": "document",
-    "Sec-Fetch-Mode": "navigate",
-    "Sec-Fetch-Site": "same-origin",
-    "Sec-Fetch-User": "?1",
-    "Pragma": "no-cache",
-    "Cache-Control": "no-cache",
-}
-
-response = requests.get(url=DQX_TWITTER, headers=headers)
+response = requests.get(url=DQX_TWITTER)
 if response.status_code != 200:
     print(f'Could not get nitter data.')
     sys.exit(1)
 
-soup = bs(response.text, 'html.parser')
-posts = soup.find_all(attrs={'class': 'timeline-item'})
+tweets = []
+rss_data = ET.fromstring(response.text)
+for row in rss_data[0].iter('item'):
+    link = row.find('link').text
+    tweet = link.split('/')[-1].rstrip('#m')
+    tweets.append(tweet)
 
-for post in posts:
-    uri = post.find(attrs={'class': 'tweet-link'})['href']
-    tweet_id = uri.split('/')[-1].replace('#m', '')
-
-    query = f"SELECT id FROM tweets WHERE id = {tweet_id}"
+for tweet in tweets:
+    query = f"SELECT id FROM tweets WHERE id = {tweet}"
     cursor.execute(query)
     results = cursor.fetchone()
 
     if not results:
         cur_time = datetime.datetime.now()
 
-        fx_link = f'https://fxtwitter.com/DQ_X/status/{tweet_id}/en'
+        fx_link = f'https://fxtwitter.com/DQ_X/status/{tweet}/en'
 
-        insert = f"INSERT INTO tweets (date, id, link) VALUES ('{cur_time}', {tweet_id}, '{fx_link}')"
+        insert = f"INSERT INTO tweets (date, id, link) VALUES ('{cur_time}', {tweet}, '{fx_link}')"
         cursor.execute(insert)
         conn.commit()
 


### PR DESCRIPTION
nitter.net's ssl cert has lapsed and it doesn't sound like they'll be renewing it. nitter.net is the main public instance. twiiit queries all public nitter instances, finds one that works and directs you to that instance instead. this should be a bit more robust. instead of parsing html, this parses an rss feed (xml) instead.

link to issue (w/o hyperlink to not associate this PR to the main nitter issue):

```
https://www.github.com/zedeus/nitter/issues/1155
```